### PR TITLE
Enhance collapsible card interaction

### DIFF
--- a/packages/web/src/components/CollapsibleCard.tsx
+++ b/packages/web/src/components/CollapsibleCard.tsx
@@ -33,13 +33,36 @@ export function CollapsibleCard({
   return (
     <Card className={className}>
       <CardHeader className="flex flex-row items-center justify-between">
-        <div className="flex items-center gap-2">
+        <div
+          className="flex items-center gap-2 cursor-pointer select-none"
+          onClick={toggle}
+          role="button"
+          aria-expanded={!isCollapsed}
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              toggle();
+            }
+          }}
+        >
           <CardTitle>{title}</CardTitle>
         </div>
         <div className="flex items-center gap-2">
           {actionsRight}
-          <Button type="button" variant="outline" size="sm" onClick={toggle}>
-            {isCollapsed ? "Mostrar" : "Minimizar"}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={toggle}
+            aria-expanded={!isCollapsed}
+            aria-label={isCollapsed ? "Mostrar" : "Minimizar"}
+          >
+            {isCollapsed ? (
+              <ChevronDownIcon className="h-4 w-4" />
+            ) : (
+              <ChevronUpIcon className="h-4 w-4" />
+            )}
           </Button>
         </div>
       </CardHeader>
@@ -49,3 +72,27 @@ export function CollapsibleCard({
 }
 
 export default CollapsibleCard;
+
+function ChevronDownIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
+      <path
+        fillRule="evenodd"
+        d="M5.23 7.21a.75.75 0 011.06.02L10 10.585l3.71-3.354a.75.75 0 111.04 1.08l-4.243 3.84a.75.75 0 01-1.041 0L5.25 8.31a.75.75 0 01-.02-1.1z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+function ChevronUpIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 20 20" fill="currentColor" {...props}>
+      <path
+        fillRule="evenodd"
+        d="M14.77 12.79a.75.75 0 01-1.06-.02L10 9.415l-3.71 3.354a.75.75 0 11-1.04-1.08l4.243-3.84a.75.75 0 011.041 0l4.217 3.84c.29.263.297.71.02 1.06z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Improve CollapsibleCard toggle with keyboard focus, aria attributes, and chevron icons
- Allow clicking the card title to expand or collapse sections

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c38de15088330a53ade36d87d4ffe