### PR TITLE
fix: persist initial form values

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -52,6 +52,7 @@ export function App() {
         >
           <InitForm
             disabled={started}
+            initialValues={initPayload ?? undefined}
             onSubmit={async (payload) => {
               // cancel previous suggest
               suggestAbortRef.current?.abort("new-suggest");
@@ -69,11 +70,11 @@ export function App() {
                 setCollapsedLive(true);
               }
             }}
-            onReset={() => {
+            onReset={(vals) => {
               setStarted(false);
               setInitResp(null);
               setTickResp(null);
-              setInitPayload(null);
+              setInitPayload(vals as any);
               setTickLocked(false);
               setTickLoading(false);
               setCollapsedInit(false);

--- a/packages/web/src/components/InitForm.js
+++ b/packages/web/src/components/InitForm.js
@@ -11,11 +11,11 @@ import { InitFormSchema } from "../schemas/forms";
 import { rankOptions } from "../data/ranks";
 import { heroOptions } from "../data/heroes";
 import { HeroIcon } from "./HeroIcon";
-export function InitForm({ disabled, onSubmit, onReset }) {
+export function InitForm({ disabled, onSubmit, onReset, initialValues }) {
     const DEFAULT_ENEMIES = React.useMemo(() => ["Void", "Jakiro", "Axe", "Clinkz", "Zeus"], []);
     const form = useForm({
         resolver: zodResolver(InitFormSchema),
-        defaultValues: {
+        defaultValues: initialValues ?? {
             rank: "Legend",
             hero: "Abaddon",
             role: "Hard Support",
@@ -37,15 +37,9 @@ export function InitForm({ disabled, onSubmit, onReset }) {
         }), className: "space-y-3", children: [_jsxs("fieldset", { disabled: disabled || submitting, className: "space-y-3", children: [_jsxs("div", { className: "grid gap-3 sm:grid-cols-3", children: [_jsxs("div", { children: [_jsx(Label, { children: "Rango" }), _jsx(Select, { value: form.watch("rank"), onChange: (e) => form.setValue("rank", e.target.value, {
                                             shouldValidate: true,
                                         }), size: "sm", children: rankOptions.map((o) => (_jsx("option", { value: o.label, children: o.label }, o.value))) })] }), _jsxs("div", { children: [_jsx(Label, { children: "H\u00E9roe" }), _jsx(Combobox, { options: heroOptions, value: form.watch("hero"), onChange: (v) => form.setValue("hero", v, { shouldValidate: true }), onConfirm: (v) => form.setValue("hero", v, { shouldValidate: true }), placeholder: "Buscar h\u00E9roe", size: "sm", renderValue: (v) => (_jsx("div", { className: "pointer-events-none", children: _jsx(HeroIcon, { name: v, size: 18 }) })), renderOption: (opt) => (_jsxs("div", { className: "flex items-center gap-2", children: [_jsx(HeroIcon, { name: opt.label, size: 18 }), _jsx("span", { children: opt.label })] })) })] }), _jsxs("div", { children: [_jsx(Label, { children: "Rol" }), _jsx(Select, { value: form.watch("role"), onChange: (e) => form.setValue("role", e.target.value, { shouldValidate: true }), size: "sm", children: ["Mid", "Offlane", "Hard Carry", "Support", "Hard Support"].map((r) => (_jsx("option", { value: r, children: r }, r))) })] })] }), _jsxs("div", { children: [_jsx(Label, { children: "Enemigos (5 exactos)" }), _jsx(MultiCombobox, { options: heroOptions, values: form.watch("enemies"), onChange: (vals) => form.setValue("enemies", vals, { shouldValidate: true }), placeholder: "Agregar (Enter, coma o Tab)", maxSelections: 5, size: "sm", renderTag: (v) => (_jsxs("span", { className: "inline-flex items-center gap-2", children: [_jsx(HeroIcon, { name: v, size: 16 }), _jsx("span", { children: v })] })), renderOption: (opt) => (_jsxs("div", { className: "flex items-center gap-2", children: [_jsx(HeroIcon, { name: opt.label, size: 18 }), _jsx("span", { children: opt.label })] })) }), _jsx("div", { className: "help mt-1 text-xs text-slate-400/80", children: "Selecciona 5 h\u00E9roes enemigos." })] })] }), _jsxs("div", { className: "flex items-center gap-3 pt-1", children: [_jsx(Button, { type: "submit", variant: "primary", disabled: submitting || !exactlyFive || !!disabled, "aria-live": "polite", children: submitting ? "Enviando…" : "Generar build inicial" }), !exactlyFive && !submitting && !disabled && (_jsx("div", { className: "text-xs text-amber-600", children: "Selecciona 5 enemigos para continuar." })), disabled && (_jsxs(_Fragment, { children: [_jsxs("div", { className: "inline-flex items-center gap-1.5 text-sm text-slate-600", children: [_jsx("span", { className: "inline-block h-2 w-2 rounded-full bg-emerald-500" }), "Partida en curso"] }), _jsx(Button, { type: "button", variant: "outline", onClick: () => {
-                                    form.reset({
-                                        rank: "Legend",
-                                        hero: "Abaddon",
-                                        role: "Hard Support",
-                                        enemies: DEFAULT_ENEMIES,
-                                        patch: "7.39d",
-                                        constraints: "",
-                                    });
-                                    onReset?.();
+                                    const vals = form.getValues();
+                                    form.reset(vals);
+                                    onReset?.(vals);
                                 }, children: "Reiniciar partida" })] }))] })] }));
 }
 export default InitForm;

--- a/packages/web/src/components/InitForm.tsx
+++ b/packages/web/src/components/InitForm.tsx
@@ -14,10 +14,11 @@ import { HeroIcon } from "./HeroIcon";
 export type InitFormProps = {
   disabled?: boolean;
   onSubmit: (payload: InitFormValues) => void | Promise<void>;
-  onReset?: () => void;
+  onReset?: (vals: InitFormValues) => void;
+  initialValues?: InitFormValues;
 };
 
-export function InitForm({ disabled, onSubmit, onReset }: InitFormProps) {
+export function InitForm({ disabled, onSubmit, onReset, initialValues }: InitFormProps) {
   const DEFAULT_ENEMIES = React.useMemo(
     () => ["Void", "Jakiro", "Axe", "Clinkz", "Zeus"],
     []
@@ -25,14 +26,15 @@ export function InitForm({ disabled, onSubmit, onReset }: InitFormProps) {
 
   const form = useForm<InitFormValues>({
     resolver: zodResolver(InitFormSchema),
-    defaultValues: {
-      rank: "Legend",
-      hero: "Abaddon",
-      role: "Hard Support",
-      enemies: DEFAULT_ENEMIES,
-      patch: "7.39d",
-      constraints: "",
-    },
+    defaultValues:
+      initialValues ?? {
+        rank: "Legend",
+        hero: "Abaddon",
+        role: "Hard Support",
+        enemies: DEFAULT_ENEMIES,
+        patch: "7.39d",
+        constraints: "",
+      },
     mode: "onChange",
   });
 
@@ -168,15 +170,9 @@ export function InitForm({ disabled, onSubmit, onReset }: InitFormProps) {
               type="button"
               variant="outline"
               onClick={() => {
-                form.reset({
-                  rank: "Legend",
-                  hero: "Abaddon",
-                  role: "Hard Support",
-                  enemies: DEFAULT_ENEMIES,
-                  patch: "7.39d",
-                  constraints: "",
-                });
-                onReset?.();
+                const vals = form.getValues();
+                form.reset(vals);
+                onReset?.(vals);
               }}
             >
               Reiniciar partida


### PR DESCRIPTION
## Summary
- keep initial form selections after generating a build or restarting
- store last input as defaults for subsequent sessions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d0c499b2483308b91a1a5db57b88b